### PR TITLE
[PREVIEW] SL-1147 use master events service for PR builds

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,7 @@
 locals {
   app_full_name = "${var.product}-${var.component}"
+
+  events_url = "${replace(var.env, "PR-", "") != var.env ? http://snl-events-aat.service.core-compute-aat.internal : http://snl-events-${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal}"
 }
 module "snl-api" {
   source               = "git@github.com:hmcts/moj-module-webapp"
@@ -14,6 +16,6 @@ module "snl-api" {
   common_tags          = "${var.common_tags}"
 
   app_settings = {
-   SNL_EVENTS_URL = "http://snl-events-${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal"
+   SNL_EVENTS_URL = "${local.events_url}"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,7 +1,9 @@
 locals {
   app_full_name = "${var.product}-${var.component}"
 
-  events_url = "${var.env == "preview" ? http://snl-events-aat.service.core-compute-aat.internal : http://snl-events-${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal}"
+  aat_events_url = "http://snl-events-aat.service.core-compute-aat.internal"
+  local_events_url = "http://snl-events-${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal"
+  events_url = "${var.env == "preview" ? local.aat_events_url : local.local_events_url}"
 }
 module "snl-api" {
   source               = "git@github.com:hmcts/moj-module-webapp"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,7 +1,7 @@
 locals {
   app_full_name = "${var.product}-${var.component}"
 
-  events_url = "${replace(var.env, "PR-", "") != var.env ? http://snl-events-aat.service.core-compute-aat.internal : http://snl-events-${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal}"
+  events_url = "${var.env == "preview" ? http://snl-events-aat.service.core-compute-aat.internal : http://snl-events-${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal}"
 }
 module "snl-api" {
   source               = "git@github.com:hmcts/moj-module-webapp"


### PR DESCRIPTION
For PR build any services used in snl-api should be running against masters of other services (the latest stable version)