### PR TITLE
SL-1109: added isListed param to get all hearing part endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlapi/controllers/HearingPartController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlapi/controllers/HearingPartController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.sandl.snlapi.services.EventsCommunicationService;
 
 import java.util.Optional;

--- a/src/main/java/uk/gov/hmcts/reform/sandl/snlapi/controllers/HearingPartController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sandl/snlapi/controllers/HearingPartController.java
@@ -11,7 +11,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.sandl.snlapi.services.EventsCommunicationService;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/hearing-part")
@@ -22,8 +25,9 @@ public class HearingPartController {
 
     @GetMapping(path = "", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public String getHearingParts() {
-        return eventsCommunicationService.makeCall("/hearing-part", HttpMethod.GET).getBody();
+    public String getHearingParts(@RequestParam("isListed") Optional<Boolean> isListed) {
+        String url = "/hearing-part" +  (isListed.isPresent() ? "?isListed=" + isListed.get() : "");
+        return eventsCommunicationService.makeCall(url, HttpMethod.GET).getBody();
     }
 
     @PutMapping(path = "", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/uk/gov/hmcts/reform/sandl/snlapi/controllers/HearingPartControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sandl/snlapi/controllers/HearingPartControllerTest.java
@@ -29,6 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class HearingPartControllerTest {
 
     private static String HEARINGS_URL = "/hearing-part";
+    private static String HEARINGS_WITH_IS_LISTED_PARAM_URL = "/hearing-part?isListed=false";
+    private static String HEARINGS_WITH_WRONG_LISTED_PARAM_URL = "/hearing-part?isListed=";
+    private static String RESPONSE_BODY = "A";
 
     @Configuration
     @Import(HearingPartController.class)
@@ -45,24 +48,48 @@ public class HearingPartControllerTest {
 
     @Test
     public void getHearingParts_returnsOk() throws Exception {
-        String responseBody = "A";
-        when(eventsCommunicationServiceMock.makeCall(HEARINGS_URL, HttpMethod.GET).getBody()).thenReturn(responseBody);
+        when(eventsCommunicationServiceMock.makeCall(HEARINGS_URL, HttpMethod.GET).getBody()).thenReturn(RESPONSE_BODY);
 
         mockMvc.perform(get(HEARINGS_URL))
             .andExpect(status().isOk())
-            .andExpect(content().string(responseBody))
+            .andExpect(content().string(RESPONSE_BODY))
+            .andReturn();
+    }
+
+    @Test
+    public void getHearingPartsWithListedParam_returnsOk() throws Exception {
+        when(eventsCommunicationServiceMock
+            .makeCall(HEARINGS_WITH_IS_LISTED_PARAM_URL, HttpMethod.GET)
+            .getBody()
+        ).thenReturn(RESPONSE_BODY);
+
+        mockMvc.perform(get(HEARINGS_WITH_IS_LISTED_PARAM_URL))
+            .andExpect(status().isOk())
+            .andExpect(content().string(RESPONSE_BODY))
+            .andReturn();
+    }
+
+    @Test
+    public void getHearingPartsWithWrongListedParam_passRequestWithoutParam() throws Exception {
+        when(eventsCommunicationServiceMock
+            .makeCall(HEARINGS_URL, HttpMethod.GET)
+            .getBody()
+        ).thenReturn(RESPONSE_BODY);
+
+        mockMvc.perform(get(HEARINGS_WITH_WRONG_LISTED_PARAM_URL))
+            .andExpect(status().isOk())
+            .andExpect(content().string(RESPONSE_BODY))
             .andReturn();
     }
 
     @Test
     public void upsertHearingPart_withCorrectParametersReturnsOk() throws Exception {
-        String requestBody = "A";
-        when(eventsCommunicationServiceMock.makePutCall(HEARINGS_URL, requestBody))
+        when(eventsCommunicationServiceMock.makePutCall(HEARINGS_URL, RESPONSE_BODY))
             .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
         mockMvc.perform(put(HEARINGS_URL)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody))
+            .content(RESPONSE_BODY))
             .andExpect(status().isOk())
             .andReturn();
     }


### PR DESCRIPTION
Added `isListed` param to get all hearing part. When is passed it returns only hearing parts that have or have not assigned session. When passed malformed URL e.g. `hearingPart?isListed=` it returns all hearing parts

Tests included